### PR TITLE
Update ESLint version in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"author": "Will Honey",
 	"license": "MIT",
 	"peerDependencies": {
-		"eslint": "2.x - 5.x"
+		"eslint": "2.x - 6.x"
 	},
 	"devDependencies": {
 		"@types/node": "^11.12.2",


### PR DESCRIPTION
ESLint 6 [was released](https://github.com/eslint/eslint/blob/master/CHANGELOG.md). You awesome plugin works great with the new version. We just need to update `peerDependencies` to fix the warning:

```
warning " > eslint-plugin-import-helpers@1.0.1" has incorrect peer dependency "eslint@2.x - 5.x".
```