### PR TITLE
Allow unassigned imports

### DIFF
--- a/docs/rules/order-imports.md
+++ b/docs/rules/order-imports.md
@@ -156,7 +156,7 @@ Unassigned imports refers to imports which are not assigned to any variable but 
 Example:
 ```js
 import 'polyfill'
-import 'containers/styles.scss'
+import 'styles.scss'
 ```
 
 By default unassigned imports are ignored, as the order they are imported in may be important.

--- a/docs/rules/order-imports.md
+++ b/docs/rules/order-imports.md
@@ -23,7 +23,7 @@ import main from './';
 
 Notes:
 
--   Unassigned imports are ignored (ex: `import 'polyfill'`), as the order they are imported in may be important.
+-   Unassigned imports are ignored (ex: `import 'polyfill'`), as the order they are imported in may be important. Use 'unassignedImports' option if you'd like to allow them.
 -   Statements using the ES6 `import` syntax must appear before any `require()` statements.
 
 ## Usage
@@ -147,6 +147,60 @@ This will fail the rule check:
 import foo from 'foo';
 import bar from 'bar';
 import Baz from 'Baz';
+```
+
+### `unassignedImports: [ignore|allow] (default: ignore)`
+
+Unassigned imports refers to imports which are not assigned to any variable but are imported globally.
+
+Example:
+```js
+import 'polyfill'
+import 'containers/styles.scss'
+```
+
+By default unassigned imports are ignored, as the order they are imported in may be important.
+
+-  If set to `allow`, considers unassigned imports like any other imports when ordering.
+-  If set to `ignore`, does not consider the ordering for this import.
+
+Examples:
+
+#### ignore
+```js
+/* eslint import-helpers/order-imports: [
+    "error",
+    {
+        unassignedImports: 'ignore',
+        groups: [['module'], '/\.scss$/']
+    },
+] */
+
+/* Any placement of 'styles.scss' is VALID */
+import 'styles.scss';
+import fs from 'fs';
+import path from 'path';
+```
+
+#### allow
+```js
+/* eslint import-helpers/order-imports: [
+    "error",
+    {
+        unassignedImports: 'allow',
+        groups: [['module'], '/\.scss$/']
+    },
+] */
+
+/* INVALID */
+import 'styles.scss'
+import fs from 'fs';
+import path from 'path';
+
+/* VALID */
+import fs from 'fs';
+import path from 'path';
+import 'styles.scss'
 ```
 
 ## Upgrading from v0.14 to v1

--- a/src/rules/order-imports.ts
+++ b/src/rules/order-imports.ts
@@ -17,10 +17,14 @@ const alphabetizeOptions: AlphabetizeOption[] = ['ignore', 'asc', 'desc'];
 type Groups = (ValidImportType | ValidImportType[])[];
 const defaultGroups: Groups = ['absolute', 'module', 'parent', 'sibling', 'index'];
 
+type UnassignedImportsOption = 'allow' | 'ignore';
+const unassignedImportsOption: UnassignedImportsOption[] = ['allow', 'ignore'];
+
 type RuleOptions = {
 	groups?: Groups;
 	newlinesBetween?: NewLinesBetweenOption;
 	alphabetize?: Partial<AlphabetizeConfig>;
+	unassignedImports?: UnassignedImportsOption;
 };
 
 type ImportType = 'require' | 'import';
@@ -496,6 +500,9 @@ module.exports = {
 					newlinesBetween: {
 						enum: newLinesBetweenOptions,
 					},
+					unassignedImports: {
+						enum: unassignedImportsOption,
+					},
 					alphabetize: {
 						type: 'object',
 						properties: {
@@ -518,6 +525,7 @@ module.exports = {
 	create: function importOrderRule(context) {
 		const options: RuleOptions = context.options[0] || {};
 		const newlinesBetweenImports: NewLinesBetweenOption = options.newlinesBetween || 'ignore';
+		const unassignedImports = options.unassignedImports || 'ignore';
 
 		let alphabetize: AlphabetizeConfig;
 		let ranks: Ranks;
@@ -543,7 +551,7 @@ module.exports = {
 
 		return {
 			ImportDeclaration: function handleImports(node) {
-				if (node.specifiers.length) {
+				if (node.specifiers.length || unassignedImports === 'allow') {
 					// Ignoring unassigned imports
 					const name: string = node.source.value;
 					registerNode(node, name, 'import', ranks, regExpGroups, imported);

--- a/src/rules/order-imports.ts
+++ b/src/rules/order-imports.ts
@@ -182,11 +182,12 @@ function isPlainRequireModule(node): boolean {
 	);
 }
 
+const isUnassignedImportsAllowed = (context) => getOptions(context).unassignedImports === 'allow';
+
 function isAllowedImportModule(node: NodeOrToken, context): boolean {
-	const unassignedImportsAllowed = getOptions(context).unassignedImports === 'allow';
 	const hasNodeSpecifier = node.specifiers != null && node.specifiers.length > 0;
 
-	return node.type === 'ImportDeclaration' && (hasNodeSpecifier || unassignedImportsAllowed);
+	return node.type === 'ImportDeclaration' && (hasNodeSpecifier || isUnassignedImportsAllowed(context));
 }
 
 function canCrossNodeWhileReorder(node: NodeOrToken, context): boolean {
@@ -566,7 +567,8 @@ module.exports = {
 				}
 			},
 			CallExpression: function handleRequires(node) {
-				if (level !== 0 || !isStaticRequire(node) || !isInVariableDeclarator(node.parent)) {
+				const isUnassignedRequire = !isInVariableDeclarator(node.parent);
+				if (level !== 0 || !isStaticRequire(node) || (!isUnassignedImportsAllowed(context) && isUnassignedRequire)) {
 					return;
 				}
 				const name: string = node.arguments[0].value;

--- a/test/rules/order-imports.js
+++ b/test/rules/order-imports.js
@@ -108,6 +108,15 @@ ruleTester.run('order', rule, {
         import path from 'path';
     `,
 		}),
+		// Consider unassigned values when option is provided (import)
+		test({
+		    code: `
+	import 'fs';
+	import path from 'path';
+	import './foo';
+    `,
+		    options: [{ unassignedImports: 'allow' }],
+		},),
 		// No imports
 		test({
 			code: `
@@ -1471,29 +1480,23 @@ comment3 */", // the spacing here is really sensitive
 				},
 			],
 		}),
-		// Option unassignedImports: 'allow' should consider unassigned imports when sorting for respective groups
+		// Option unassignedImports: 'allow' should consider unassigned module imports
 		test({
 			code: `
-				import './an-unassigned-relative';
-				import path from 'path';
-				import _ from './relative';
-				import 'an-unassigned-module';
+			import './foo';
+			import 'fs';
+			import path from 'path';
 		      `,
 			output: `
-				import './an-unassigned-relative';
-				import path from 'path';
-				import _ from './relative';
-				import 'an-unassigned-module';
+			import 'fs';
+			import path from 'path';
+			import './foo';
 		      `,
 			options: [{ unassignedImports: 'allow' }],
 			errors: [
 				{
-					line: 3,
-					message: '`path` import should occur before import of `./an-unassigned-relative`',
-				},
-				{
-					line: 5,
-					message: '`an-unassigned-module` import should occur before import of `./an-unassigned-relative`',
+					line: 2,
+					message: '`./foo` import should occur after import of `path`',
 				},
 			],
 		}),

--- a/test/rules/order-imports.js
+++ b/test/rules/order-imports.js
@@ -1471,5 +1471,31 @@ comment3 */", // the spacing here is really sensitive
 				},
 			],
 		}),
+		// Option unassignedImports: 'allow' should consider unassigned imports when sorting for respective groups
+		test({
+			code: `
+				import './an-unassigned-relative';
+				import path from 'path';
+				import _ from './relative';
+				import 'an-unassigned-module';
+		      `,
+			output: `
+				import './an-unassigned-relative';
+				import path from 'path';
+				import _ from './relative';
+				import 'an-unassigned-module';
+		      `,
+			options: [{ unassignedImports: 'allow' }],
+			errors: [
+				{
+					line: 3,
+					message: '`path` import should occur before import of `./an-unassigned-relative`',
+				},
+				{
+					line: 5,
+					message: '`an-unassigned-module` import should occur before import of `./an-unassigned-relative`',
+				},
+			],
+		}),
 	],
 });


### PR DESCRIPTION
#### What?
Add a way to allow sorting for unassigned imports. Please check the updated order-imports.md for documentation.

Resolves issues: https://github.com/Tibfib/eslint-plugin-import-helpers/issues/35 https://github.com/Tibfib/eslint-plugin-import-helpers/issues/24

#### My Usecase
A very common use-case is to have style imports `import 'some-style.scss'` sorted at the end of the file when building react components. Even after defining a separate group for these files `/\.scss$/`, the sorting didn't work because we ignore unassigned imports. This change lets the user enable this option if they'd like.