### PR TITLE
Add/fix internal linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+# Compiled
+lib/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,38 @@
+module.exports = {
+	root: true,
+	parserOptions: {
+		ecmaVersion: 2021,
+		sourceType: 'module',
+	},
+	extends: [
+		'eslint:recommended',
+		'plugin:eslint-plugin/recommended',
+		'plugin:node/recommended',
+		'plugin:prettier/recommended',
+	],
+	env: {
+		node: true,
+	},
+	settings: {
+		node: {
+			tryExtensions: ['.js', '.json', '.node', '.ts', '.d.ts'],
+		},
+	},
+	rules: {},
+	overrides: [
+		{
+			files: ['test/**/*.js'],
+			env: {
+				mocha: true,
+			},
+		},
+		{
+			parser: '@typescript-eslint/parser',
+			files: ['*.ts'],
+			extends: ['plugin:@typescript-eslint/recommended'],
+			rules: {
+				'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
+			},
+		},
+	],
+};

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ src
 docs
 node_modules
 test-results
+gulpfile.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,15 +6,12 @@ const SRC = 'src/**/?(*.js|*.ts)';
 const DEST = 'lib';
 const tsProject = ts.createProject('tsconfig.json');
 
-gulp.task('clean', function(done) {
+gulp.task('clean', function (done) {
 	rimraf(DEST, done);
 });
 
-gulp.task('src', ['clean'], function() {
-	return gulp
-		.src(SRC)
-		.pipe(tsProject())
-		.pipe(gulp.dest(DEST));
+gulp.task('src', ['clean'], function () {
+	return gulp.src(SRC).pipe(tsProject()).pipe(gulp.dest(DEST));
 });
 
 gulp.task('prepublish', ['src']);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "gulp src",
 		"lint": "npm run lint:js",
-		"lint:js": "eslint .",
+		"lint:js": "eslint --cache .",
 		"prepublish": "npm run build",
 		"test": "npm run build && npm run test-quick",
 		"test-quick": "NODE_PATH=./lib nyc -s mocha -R dot --recursive test -t test-results"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,16 @@
 	"main": "lib/index.js",
 	"scripts": {
 		"build": "gulp src",
+		"lint": "npm run lint:js",
+		"lint:js": "eslint .",
 		"prepublish": "npm run build",
 		"test": "npm run build && npm run test-quick",
 		"test-quick": "NODE_PATH=./lib nyc -s mocha -R dot --recursive test -t test-results"
 	},
 	"keywords": [
 		"eslint",
+		"eslint-plugin",
+		"eslintplugin",
 		"import",
 		"eslint-plugin-import",
 		"configurable"
@@ -25,12 +29,18 @@
 	},
 	"devDependencies": {
 		"@types/node": "^14.17.33",
+		"@typescript-eslint/eslint-plugin": "^5.9.0",
 		"@typescript-eslint/parser": "^5.3.1",
-		"eslint": "^8.2.0",
+		"eslint": "^8.6.0",
+		"eslint-config-prettier": "^8.3.0",
+		"eslint-plugin-eslint-plugin": "^4.1.0",
+		"eslint-plugin-node": "^11.1.0",
+		"eslint-plugin-prettier": "^4.0.0",
 		"gulp": "^3.9.0",
 		"gulp-typescript": "^5.0.1",
 		"mocha": "^6.1.2",
 		"nyc": "^13.3.0",
+		"prettier": "^2.5.1",
 		"rimraf": "^3.0.2",
 		"typescript": "^4.4.4"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,0 @@
-export const rules = {
-	'order-imports': require('./rules/order-imports'),
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,7 @@
+import orderImports from './rules/order-imports';
+
+export = {
+	rules: {
+		'order-imports': orderImports,
+	},
+};

--- a/src/rules/order-imports.ts
+++ b/src/rules/order-imports.ts
@@ -35,7 +35,7 @@ type Imported = { name: string; rank: number; node: NodeOrToken };
 
 function reverse(array: Imported[]) {
 	return array
-		.map(function(v) {
+		.map(function (v) {
 			return {
 				name: v.name,
 				rank: -v.rank,
@@ -102,7 +102,7 @@ function findOutOfOrder(imported) {
 		return [];
 	}
 	let maxSeenRankNode = imported[0];
-	return imported.filter(function(importedModule) {
+	return imported.filter(function (importedModule) {
 		const res = importedModule.rank < maxSeenRankNode.rank;
 		if (maxSeenRankNode.rank < importedModule.rank) {
 			maxSeenRankNode = importedModule;
@@ -121,7 +121,7 @@ function findRootNode(node) {
 
 function findEndOfLineWithComments(sourceCode, node) {
 	const tokensToEndOfLine = takeTokensAfterWhile(sourceCode, node, commentOnSameLineAs(node));
-	let endOfTokens =
+	const endOfTokens =
 		tokensToEndOfLine.length > 0 ? tokensToEndOfLine[tokensToEndOfLine.length - 1].range[1] : node.range[1];
 	let result = endOfTokens;
 	for (let i = endOfTokens; i < sourceCode.text.length; i++) {
@@ -146,7 +146,7 @@ function commentOnSameLineAs(node): (token: NodeOrToken) => boolean {
 
 function findStartOfLineWithComments(sourceCode, node) {
 	const tokensToEndOfLine = takeTokensBeforeWhile(sourceCode, node, commentOnSameLineAs(node));
-	let startOfTokens = tokensToEndOfLine.length > 0 ? tokensToEndOfLine[0].range[0] : node.range[0];
+	const startOfTokens = tokensToEndOfLine.length > 0 ? tokensToEndOfLine[0].range[0] : node.range[0];
 	let result = startOfTokens;
 	for (let i = startOfTokens - 1; i > 0; i--) {
 		if (sourceCode.text[i] !== ' ' && sourceCode.text[i] !== '\t') {
@@ -192,7 +192,7 @@ function canReorderItems(firstNode: NodeOrToken, secondNode: NodeOrToken): boole
 	const firstIndex = parent.body.indexOf(firstNode);
 	const secondIndex = parent.body.indexOf(secondNode);
 	const nodesBetween = parent.body.slice(firstIndex, secondIndex + 1);
-	for (var nodeBetween of nodesBetween) {
+	for (const nodeBetween of nodesBetween) {
 		if (!canCrossNodeWhileReorder(nodeBetween)) {
 			return false;
 		}
@@ -247,7 +247,7 @@ function fixOutOfOrder(context, firstNode: NodeOrToken, secondNode: NodeOrToken,
 }
 
 function reportOutOfOrder(context, imported: Imported[], outOfOrder, order: 'before' | 'after'): void {
-	outOfOrder.forEach(function(imp) {
+	outOfOrder.forEach(function (imp) {
 		const found = imported.find(function hasHigherRank(importedItem) {
 			return importedItem.rank > imp.rank;
 		});
@@ -271,7 +271,7 @@ function makeOutOfOrderReport(context, imported: Imported[]) {
 }
 
 function mutateRanksToAlphabetize(imported, order, ignoreCase) {
-	const groupedByRanks = imported.reduce(function(acc, importedItem) {
+	const groupedByRanks = imported.reduce(function (acc, importedItem) {
 		acc[importedItem.rank] = acc[importedItem.rank] || [];
 		acc[importedItem.rank].push(importedItem.name);
 		return acc;
@@ -280,8 +280,8 @@ function mutateRanksToAlphabetize(imported, order, ignoreCase) {
 	const groupRanks = Object.keys(groupedByRanks);
 
 	// sort imports locally within their group
-	groupRanks.forEach(function(groupRank) {
-		groupedByRanks[groupRank].sort(function(importA, importB) {
+	groupRanks.forEach(function (groupRank) {
+		groupedByRanks[groupRank].sort(function (importA, importB) {
 			return ignoreCase ? importA.localeCompare(importB) : importA < importB ? -1 : importA === importB ? 0 : 1;
 		});
 
@@ -291,15 +291,15 @@ function mutateRanksToAlphabetize(imported, order, ignoreCase) {
 	});
 
 	// add decimal ranking to sort within the group
-	const alphabetizedRanks = groupRanks.sort().reduce(function(acc, groupRank) {
-		groupedByRanks[groupRank].forEach(function(importedItemName, index) {
+	const alphabetizedRanks = groupRanks.sort().reduce(function (acc, groupRank) {
+		groupedByRanks[groupRank].forEach(function (importedItemName, index) {
 			acc[importedItemName] = +groupRank + index / MAX_GROUP_SIZE;
 		});
 		return acc;
 	}, {});
 
 	// mutate the original group-rank with alphabetized-rank
-	imported.forEach(function(importedItem) {
+	imported.forEach(function (importedItem) {
 		importedItem.rank = alphabetizedRanks[importedItem.name];
 	});
 }
@@ -333,9 +333,9 @@ const knownTypes: KnownImportType[] = ['absolute', 'module', 'parent', 'sibling'
 // Example: { index: 0, sibling: 1, parent: 1, module: 2 }
 // Will throw an error if it: contains a type that does not exist in the list, does not start and end with '/', or has a duplicate
 function convertGroupsToRanks(groups: Groups): Ranks {
-	const rankObject = groups.reduce(function(res, group, index) {
+	const rankObject = groups.reduce(function (res, group, index) {
 		if (typeof group === 'string') group = [group]; // wrap them all in arrays
-		group.forEach(function(groupItem: ValidImportType) {
+		group.forEach(function (groupItem: ValidImportType) {
 			if (!isRegularExpressionGroup(groupItem) && knownTypes.indexOf(groupItem as KnownImportType) === -1) {
 				throw new Error(
 					`Incorrect configuration of the rule: Unknown type ${JSON.stringify(
@@ -351,11 +351,11 @@ function convertGroupsToRanks(groups: Groups): Ranks {
 		return res;
 	}, {});
 
-	const omittedTypes = knownTypes.filter(function(type) {
+	const omittedTypes = knownTypes.filter(function (type) {
 		return rankObject[type] === undefined;
 	});
 
-	return omittedTypes.reduce(function(res, type) {
+	return omittedTypes.reduce(function (res, type) {
 		res[type] = groups.length;
 		return res;
 	}, rankObject);
@@ -400,7 +400,7 @@ function makeNewlinesBetweenReport(
 	};
 	let previousImport = imported[0];
 
-	imported.slice(1).forEach(function(currentImport) {
+	imported.slice(1).forEach(function (currentImport) {
 		const emptyLinesBetween: number = getNumberOfEmptyLinesBetween(currentImport, previousImport);
 
 		const currentGroupRank = Math.floor(currentImport.rank); // each group rank is a whole number, within a group, decimals indicate subranking. yeah, not great.
@@ -479,7 +479,7 @@ function getAlphabetizeConfig(options: RuleOptions): AlphabetizeConfig {
 	return { order, ignoreCase };
 }
 
-module.exports = {
+export default {
 	meta: {
 		type: 'suggestion',
 		docs: {
@@ -531,8 +531,8 @@ module.exports = {
 		} catch (error) {
 			// Malformed configuration
 			return {
-				Program: function(node) {
-					context.report(node, error.message);
+				Program: function (node) {
+					context.report({ node, message: error.message });
 				},
 			};
 		}

--- a/src/util/import-type.ts
+++ b/src/util/import-type.ts
@@ -3,7 +3,7 @@ export function isAbsolute(name: string): boolean {
 }
 
 // a module is anything that doesn't start with a . or a / or a \
-const moduleRegExp = /^[^\/\\.]/;
+const moduleRegExp = /^[^/\\.]/;
 export function isModule(name: string): boolean {
 	return moduleRegExp.test(name);
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,0 @@
----
-env:
-  mocha: true
-rules:
-  no-unused-expressions: 0
-  max-len: 0

--- a/test/rules/order-imports-2.js
+++ b/test/rules/order-imports-2.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 const { test } = require('../utils');
 
 const ruleTester = new RuleTester();
-const rule = require('rules/order-imports');
+const { default: rule } = require('../../lib/rules/order-imports');
 
 ruleTester.run('order', rule, {
 	valid: [

--- a/test/rules/order-imports.js
+++ b/test/rules/order-imports.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 const { test } = require('../utils');
 
 const ruleTester = new RuleTester();
-const rule = require('rules/order-imports');
+const { default: rule } = require('../../lib/rules/order-imports');
 
 function withoutAutofixOutput(test) {
 	return Object.assign({}, test, { output: test.code });
@@ -137,7 +137,14 @@ ruleTester.run('order', rule, {
         var relParent3 = require('../');
         var relParent1 = require('../foo');
       `,
-			options: [{ groups: [['module', 'index'], ['sibling', 'parent']] }],
+			options: [
+				{
+					groups: [
+						['module', 'index'],
+						['sibling', 'parent'],
+					],
+				},
+			],
 		}),
 		// Omitted types should implicitly be considered as the last type
 		test({
@@ -482,10 +489,12 @@ ruleTester.run('order', rule, {
 		// With large number of imports in the same group to ensure no newlines are inserted into group.
 		test({
 			code: generateImports(150),
-			options: [{
-				newlinesBetween: 'always',
-				alphabetize: { order: 'asc',},
-		  	}],
+			options: [
+				{
+					newlinesBetween: 'always',
+					alphabetize: { order: 'asc' },
+				},
+			],
 		}),
 	],
 	invalid: [
@@ -612,13 +621,11 @@ ruleTester.run('order', rule, {
 		}),
 		// fix order with multilines comments at the end and start of line
 		test({
-			code:
-				"/* multiline1\n\
+			code: "/* multiline1\n\
 comment1 */var parent = require('../parent'); /* multiline2\n\
 comment2 */  var fs = require('fs');/* multiline3\n\
 comment3 */",
-			output:
-				"/* multiline1\n\
+			output: "/* multiline1\n\
 comment1 */  var fs = require('fs');\n\
 var parent = require('../parent'); /* multiline2\n\
 comment2 *//* multiline3\n\
@@ -776,7 +783,7 @@ comment3 */", // the spacing here is really sensitive
 		  `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./foo`',
+						message: '`fs` import should occur before import of `./foo`',
 					},
 				],
 			})
@@ -790,7 +797,7 @@ comment3 */", // the spacing here is really sensitive
 		  `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./foo`',
+						message: '`fs` import should occur before import of `./foo`',
 					},
 				],
 			})
@@ -806,7 +813,7 @@ comment3 */", // the spacing here is really sensitive
 		  `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./foo`',
+						message: '`fs` import should occur before import of `./foo`',
 					},
 				],
 			})
@@ -822,7 +829,7 @@ comment3 */", // the spacing here is really sensitive
 		  `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./foo`',
+						message: '`fs` import should occur before import of `./foo`',
 					},
 				],
 			})
@@ -841,7 +848,14 @@ comment3 */", // the spacing here is really sensitive
 		    var path = require('path');
 		    var sibling = require('./foo');
 		  `,
-			options: [{ groups: [['module', 'index'], ['sibling', 'parent']] }],
+			options: [
+				{
+					groups: [
+						['module', 'index'],
+						['sibling', 'parent'],
+					],
+				},
+			],
 			errors: [
 				{
 					message: '`path` import should occur before import of `./foo`',
@@ -1116,7 +1130,10 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 			options: [
 				{
-					groups: [['module', 'index'], ['sibling', 'parent']],
+					groups: [
+						['module', 'index'],
+						['sibling', 'parent'],
+					],
 					newlinesBetween: 'always',
 				},
 			],
@@ -1243,7 +1260,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})
@@ -1258,7 +1275,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})
@@ -1272,7 +1289,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})
@@ -1286,7 +1303,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})
@@ -1301,7 +1318,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})
@@ -1316,7 +1333,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})
@@ -1331,7 +1348,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})
@@ -1346,7 +1363,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})
@@ -1361,7 +1378,7 @@ comment3 */", // the spacing here is really sensitive
 		      `,
 				errors: [
 					{
-							message: '`fs` import should occur before import of `./relative`',
+						message: '`fs` import should occur before import of `./relative`',
 					},
 				],
 			})

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,14 +80,14 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@eslint/eslintrc@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.4.tgz#dfe0ff7ba270848d10c5add0715e04964c034b31"
-  integrity sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==
+"@eslint/eslintrc@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"
+  integrity sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.0.0"
+    espree "^9.2.0"
     globals "^13.9.0"
     ignore "^4.0.6"
     import-fresh "^3.2.1"
@@ -95,16 +95,16 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@humanwhocodes/config-array@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.6.0.tgz#b5621fdb3b32309d2d16575456cbc277fa8f021a"
-  integrity sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==
+"@humanwhocodes/config-array@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
+  integrity sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==
   dependencies:
-    "@humanwhocodes/object-schema" "^1.2.0"
+    "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
     minimatch "^3.0.4"
 
-"@humanwhocodes/object-schema@^1.2.0":
+"@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
@@ -135,10 +135,42 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/node@^14.17.33":
   version "14.17.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.33.tgz#011ee28e38dc7aee1be032ceadf6332a0ab15b12"
   integrity sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==
+
+"@typescript-eslint/eslint-plugin@^5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.0.tgz#382182d5cb062f52aac54434cfc47c28898c8006"
+  integrity sha512-qT4lr2jysDQBQOPsCCvpPUZHjbABoTJW8V9ZzIYKHMfppJtpdtzszDYsldwhFxlhvrp7aCHeXD1Lb9M1zhwWwQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "5.9.0"
+    "@typescript-eslint/scope-manager" "5.9.0"
+    "@typescript-eslint/type-utils" "5.9.0"
+    debug "^4.3.2"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.2.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/experimental-utils@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.0.tgz#652762d37d6565ef07af285021b8347b6c79a827"
+  integrity sha512-ZnLVjBrf26dn7ElyaSKa6uDhqwvAi4jBBmHK1VxuFGPRAxhdi18ubQYSGA7SRiFiES3q9JiBOBHEBStOFkwD2g==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.9.0"
+    "@typescript-eslint/types" "5.9.0"
+    "@typescript-eslint/typescript-estree" "5.9.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^5.3.1":
   version "5.3.1"
@@ -158,10 +190,32 @@
     "@typescript-eslint/types" "5.3.1"
     "@typescript-eslint/visitor-keys" "5.3.1"
 
+"@typescript-eslint/scope-manager@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.9.0.tgz#02dfef920290c1dcd7b1999455a3eaae7a1a3117"
+  integrity sha512-DKtdIL49Qxk2a8icF6whRk7uThuVz4A6TCXfjdJSwOsf+9ree7vgQWcx0KOyCdk0i9ETX666p4aMhrRhxhUkyg==
+  dependencies:
+    "@typescript-eslint/types" "5.9.0"
+    "@typescript-eslint/visitor-keys" "5.9.0"
+
+"@typescript-eslint/type-utils@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.9.0.tgz#fd5963ead04bc9b7af9c3a8e534d8d39f1ce5f93"
+  integrity sha512-uVCb9dJXpBrK1071ri5aEW7ZHdDHAiqEjYznF3HSSvAJXyrkxGOw2Ejibz/q6BXdT8lea8CMI0CzKNFTNI6TEQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "5.9.0"
+    debug "^4.3.2"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/types@5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.3.1.tgz#afaa715b69ebfcfde3af8b0403bf27527912f9b7"
   integrity sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==
+
+"@typescript-eslint/types@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.9.0.tgz#e5619803e39d24a03b3369506df196355736e1a3"
+  integrity sha512-mWp6/b56Umo1rwyGCk8fPIzb9Migo8YOniBGPAQDNC6C52SeyNGN4gsVwQTAR+RS2L5xyajON4hOLwAGwPtUwg==
 
 "@typescript-eslint/typescript-estree@5.3.1":
   version "5.3.1"
@@ -176,6 +230,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.0.tgz#0e5c6f03f982931abbfbc3c1b9df5fbf92a3490f"
+  integrity sha512-kxo3xL2mB7XmiVZcECbaDwYCt3qFXz99tBSuVJR4L/sR7CJ+UNAPrYILILktGj1ppfZ/jNt/cWYbziJUlHl1Pw==
+  dependencies:
+    "@typescript-eslint/types" "5.9.0"
+    "@typescript-eslint/visitor-keys" "5.9.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz#c2860ff22939352db4f3806f34b21d8ad00588ba"
@@ -184,15 +251,23 @@
     "@typescript-eslint/types" "5.3.1"
     eslint-visitor-keys "^3.0.0"
 
+"@typescript-eslint/visitor-keys@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.0.tgz#7585677732365e9d27f1878150fab3922784a1a6"
+  integrity sha512-6zq0mb7LV0ThExKlecvpfepiB+XEtFv/bzx7/jKSgyXTFD7qjmSu1FoiS0x3OZaiS+UIXpH2vd9O89f02RCtgw==
+  dependencies:
+    "@typescript-eslint/types" "5.9.0"
+    eslint-visitor-keys "^3.0.0"
+
 acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
-  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+acorn@^8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 ajv@^6.10.0:
   version "6.12.3"
@@ -790,13 +865,68 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-scope@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-6.0.0.tgz#9cf45b13c5ac8f3d4c50f46a5121f61b3e318978"
-  integrity sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==
+eslint-config-prettier@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
+eslint-plugin-es@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
+  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
+eslint-plugin-eslint-plugin@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-4.1.0.tgz#40ae944d79e845dc9d4a85328eea3c5bf4ae0f7d"
+  integrity sha512-QJVw+WYXJuG2469gx5G929bz7crfxySDlK1i569FkuT6dpeHDeP7MmDrKaswCx17snG25LRFD6wmVX+AO5x7Qg==
+  dependencies:
+    eslint-utils "^3.0.0"
+    estraverse "^5.2.0"
+
+eslint-plugin-node@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
+  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+  dependencies:
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
+
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
+eslint-scope@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"
+  integrity sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
+
+eslint-utils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
 
 eslint-utils@^3.0.0:
   version "3.0.0"
@@ -805,23 +935,28 @@ eslint-utils@^3.0.0:
   dependencies:
     eslint-visitor-keys "^2.0.0"
 
+eslint-visitor-keys@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
 eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0:
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
   integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
-eslint@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.2.0.tgz#44d3fb506d0f866a506d97a0fc0e90ee6d06a815"
-  integrity sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==
+eslint@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.6.0.tgz#4318c6a31c5584838c1a2e940c478190f58d558e"
+  integrity sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==
   dependencies:
-    "@eslint/eslintrc" "^1.0.4"
-    "@humanwhocodes/config-array" "^0.6.0"
+    "@eslint/eslintrc" "^1.0.5"
+    "@humanwhocodes/config-array" "^0.9.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -829,10 +964,10 @@ eslint@^8.2.0:
     doctrine "^3.0.0"
     enquirer "^2.3.5"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^6.0.0"
+    eslint-scope "^7.1.0"
     eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.0.0"
-    espree "^9.0.0"
+    eslint-visitor-keys "^3.1.0"
+    espree "^9.3.0"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -859,14 +994,14 @@ eslint@^8.2.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.0.0.tgz#e90a2965698228502e771c7a58489b1a9d107090"
-  integrity sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==
+espree@^9.2.0, espree@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.0.tgz#c1240d79183b72aaee6ccfa5a90bc9111df085a8"
+  integrity sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==
   dependencies:
-    acorn "^8.5.0"
+    acorn "^8.7.0"
     acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^3.0.0"
+    eslint-visitor-keys "^3.1.0"
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -885,6 +1020,11 @@ esrecurse@^4.3.0:
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
+
+estraverse@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0:
   version "5.1.0"
@@ -973,6 +1113,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.2.7"
@@ -1462,6 +1607,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
+ignore@^5.1.1, ignore@^5.1.8:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
 ignore@^5.1.4:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
@@ -1547,6 +1697,13 @@ is-buffer@~2.0.3:
 is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
+is-core-module@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+  dependencies:
+    has "^1.0.3"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -2471,6 +2628,11 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
 path-root-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
@@ -2528,6 +2690,18 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-hrtime@^1.0.0:
   version "1.0.3"
@@ -2642,7 +2816,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.2.0:
+regexpp@^3.0.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -2727,6 +2901,15 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.10.1:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.21.0.tgz#b51adc97f3472e6a5cf4444d34bc9d6b9037591f"
+  integrity sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==
+  dependencies:
+    is-core-module "^2.8.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -2777,6 +2960,11 @@ semver@^4.1.0:
 semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+
+semver@^6.1.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.2.1:
   version "7.3.2"
@@ -3087,6 +3275,11 @@ supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 test-exclude@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
Fixes a bunch of issues:

* Add `lint` script to run internal linting
* Add linting config with eslint / eslint-plugin-eslint-plugin / eslint-plugin-node / prettier
  * These are the plugins recommended by: https://eslint.org/docs/developer-guide/working-with-plugins#linting
  * Uses existing prettier configuration in .prettierrc
* Autofixed lint violations
* Fixed some inconsistencies with TypeScript usage
* Add npm keywords to package.json recommended by: https://eslint.org/docs/developer-guide/working-with-plugins#share-plugins

It looks like test/linting aren't running on CI, so separately GitHub Actions should be added to run those.
 