### PR TITLE
Optimized canReorderItems

### DIFF
--- a/src/rules/order-imports.ts
+++ b/src/rules/order-imports.ts
@@ -191,10 +191,13 @@ function canCrossNodeWhileReorder(node: NodeOrToken): boolean {
 function canReorderItems(firstNode: NodeOrToken, secondNode: NodeOrToken): boolean {
 	const parent = firstNode.parent;
 	const firstIndex = parent.body.indexOf(firstNode);
-	const secondIndex = parent.body.indexOf(secondNode);
-	const nodesBetween = parent.body.slice(firstIndex, secondIndex + 1);
-	for (const nodeBetween of nodesBetween) {
-		if (!canCrossNodeWhileReorder(nodeBetween)) {
+	const secondIndex = parent.body.indexOf(secondNode, firstIndex);
+	if (firstIndex === -1 || secondIndex === -1) {
+		return false;
+	}
+
+	for (let i = firstIndex; i <= secondIndex; i++) {
+		if (!canCrossNodeWhileReorder(parent.body[i])) {
 			return false;
 		}
 	}


### PR DESCRIPTION
This change replaces `.slice()` with a direct index-based loop to avoid unnecessary array allocations and improve performance.
It also adds a safety check to ensure both nodes exist in parent.body, preventing potential runtime errors when either node is not found.
Uses indexOf(..., fromIndex) to reduce lookup time for the second node.

Behavior remains unchanged for valid inputs, while the function now fails gracefully for invalid ones.